### PR TITLE
release: 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,93 @@
+## 1.0.0 (2022-12-16)
+
+
+### :package: Build
+
+* **deps-dev:** bump @vitest/coverage-c8 from 0.25.4 to 0.25.5 ([bddbfb1](https://github.com/flex-development/pathe/commit/bddbfb14373af65a8da37efbda784d18571bfa3e))
+* **deps-dev:** bump @vitest/ui from 0.25.4 to 0.25.5 ([146ebb6](https://github.com/flex-development/pathe/commit/146ebb69628420c6b652c31265b9b08eb8a13282))
+* **deps-dev:** bump esbuild from 0.15.18 to 0.16.6 ([572a453](https://github.com/flex-development/pathe/commit/572a4538ef91feaf036487c5794d8294fe52b011))
+* **deps-dev:** bump vitest from 0.25.4 to 0.25.5 ([7902e9d](https://github.com/flex-development/pathe/commit/7902e9d9b91287000cbf73cf03d8a8f0b6ad4c4d))
+* **utils:** export utilities from main entry point ([87385b7](https://github.com/flex-development/pathe/commit/87385b79af0496cf3883d8ce702b58dbb015dc39))
+
+
+### :robot: Continuous Integration
+
+* **deps:** Bump actions/checkout from 3.1.0 to 3.2.0 ([#1](https://github.com/flex-development/pathe/issues/1)) ([eec4bf9](https://github.com/flex-development/pathe/commit/eec4bf9f427dc9206ca42943fd6ffaadbe1d611a))
+* **workflows:** upload coverage reports to codecov ([9814979](https://github.com/flex-development/pathe/commit/98149796bc36b58b73d9907bcd23c9bc7786cd88))
+
+
+### :pencil: Documentation
+
+* "what is this?", "when should i use this?", api, types ([368a3c8](https://github.com/flex-development/pathe/commit/368a3c839aa3f2d9a083dfde0ec89dff3daa878d))
+* code coverage status ([6482dd9](https://github.com/flex-development/pathe/commit/6482dd9fcfe90b688ecc69b22b55861fb3e8ce46))
+* **lib:** qa ([4594d4b](https://github.com/flex-development/pathe/commit/4594d4b1136f3823ae47daf5e1ac93bd65f32341))
+* **utils:** qa ([c7e1d18](https://github.com/flex-development/pathe/commit/c7e1d18e80315e502c56a476118e2d9148adc928))
+
+
+### :sparkles: Features
+
+* `default`, `posix`, `win32` ([2021e44](https://github.com/flex-development/pathe/commit/2021e44ffe0285203471dc2dd736a4b38b5cee50))
+* **interfaces:** `Pathe` ([037d1d6](https://github.com/flex-development/pathe/commit/037d1d653ec769ca99f76b08b052a0e81850ce21))
+* **interfaces:** `PathObject` ([dabb689](https://github.com/flex-development/pathe/commit/dabb6894b13d7bbda8eee3b09ee16c797455ea77))
+* **interfaces:** `PlatformPath` ([aa82c8b](https://github.com/flex-development/pathe/commit/aa82c8be9605daf204b20dc4655eb997101f0c16))
+* **internal:** `ensurePosix` ([12e2a26](https://github.com/flex-development/pathe/commit/12e2a269ad933cf769e132d47f405e990d5fec39))
+* **internal:** `ERR_INVALID_ARG_TYPE` ([27696dc](https://github.com/flex-development/pathe/commit/27696dc65e496080318d49e59af394aa14ea4a3e))
+* **internal:** `formatExt` ([6287a90](https://github.com/flex-development/pathe/commit/6287a90078370787755863939e2f17c6c658a207))
+* **internal:** `isDrivePath` ([1e6f18d](https://github.com/flex-development/pathe/commit/1e6f18d5e394a8c9f0f22b9faef1afa9b78a97bf))
+* **internal:** `isSep` ([3ece912](https://github.com/flex-development/pathe/commit/3ece912d995366c0b30d564f082c24c6807c0181))
+* **internal:** `isUncPath` ([521bdd9](https://github.com/flex-development/pathe/commit/521bdd9727e949983524d8a9a94ab9fc96ab2439))
+* **internal:** `NodeError` ([0900ed4](https://github.com/flex-development/pathe/commit/0900ed4c3a42c0fd6224b3c8504d6cd645bec994))
+* **internal:** `normalizeString` ([1cf683e](https://github.com/flex-development/pathe/commit/1cf683e314a2c3f22ffdef934bb31f98af75fa82))
+* **internal:** `validateObject` ([7aae60f](https://github.com/flex-development/pathe/commit/7aae60f336e77286eed675efbaaeede1384f7168))
+* **internal:** `validateString` ([1eae687](https://github.com/flex-development/pathe/commit/1eae687291e74acc7b4f352f9bd63e9d2576d623))
+* **lib:** `basename` ([844df0b](https://github.com/flex-development/pathe/commit/844df0bf7fdeac365e2c5899d64ac59b1eadf16e))
+* **lib:** `delimiter` ([a4e7c00](https://github.com/flex-development/pathe/commit/a4e7c00101f88820dc7bdbc683beaab2c0dc9b5d))
+* **lib:** `dirname` ([18d449a](https://github.com/flex-development/pathe/commit/18d449af8a5ece7f3f67012d9e93ac6d2bd9a328))
+* **lib:** `extname` ([e710004](https://github.com/flex-development/pathe/commit/e710004dfee3a01e77283422a5aab71354fab4df))
+* **lib:** `format` ([56e3061](https://github.com/flex-development/pathe/commit/56e3061e4d864d33869482740566c895fc643691))
+* **lib:** `isAbsolute` ([df42e5c](https://github.com/flex-development/pathe/commit/df42e5c00f7e8190d692e49729bd74b608b9a12d))
+* **lib:** `join` ([78a41a2](https://github.com/flex-development/pathe/commit/78a41a2be736af4401568ff1a51417d21b4b5d78))
+* **lib:** `normalize` ([d937719](https://github.com/flex-development/pathe/commit/d93771982af37fb042f5db59d0fd1298a660e0be))
+* **lib:** `parse` ([98c393a](https://github.com/flex-development/pathe/commit/98c393a5f9bb11253181532a224bd4a99a38b00e))
+* **lib:** `relative` ([89bb9f8](https://github.com/flex-development/pathe/commit/89bb9f89aa454edb339471713b700acad1aff189))
+* **lib:** `resolve` ([e3aeab3](https://github.com/flex-development/pathe/commit/e3aeab3b438d099f5e274369c859acb312876701))
+* **lib:** `sep` ([3f2df46](https://github.com/flex-development/pathe/commit/3f2df46c37eb18f8b1052d7957c061fa6e295c44))
+* **lib:** `toNamespacedPath` ([6a8e59c](https://github.com/flex-development/pathe/commit/6a8e59c9d40c2683d263d8ca674eabec5fe6c244))
+* **types:** `Delimiter` ([ee790c3](https://github.com/flex-development/pathe/commit/ee790c3e7afe2cdc9b296eb6604b2995db620f5e))
+* **types:** `Ext` ([6fb7173](https://github.com/flex-development/pathe/commit/6fb7173fd9781d64f985da62e3e360299c17bec1))
+* **types:** `Sep` ([054b623](https://github.com/flex-development/pathe/commit/054b623fefe35a88de4eb3dd11dfede1bd303db3))
+* **utils:** `addExt` ([e4b3ad8](https://github.com/flex-development/pathe/commit/e4b3ad8685431152c43efe961bba3e9acf3f6e03))
+* **utils:** `changeExt` ([10b1917](https://github.com/flex-development/pathe/commit/10b1917ae5750100888899bc1f0645b45d848851))
+* **utils:** `defaultExt` ([582e287](https://github.com/flex-development/pathe/commit/582e287137cd2b9460044f9e825b4a8ed457a0fa))
+* **utils:** `removeExt` ([de150ee](https://github.com/flex-development/pathe/commit/de150ee4ece55c00d8abc956f788baf4bc0385f0))
+
+
+### :bug: Fixes
+
+* **interfaces:** [`PlatformPath`] interface import statements ([b2e088f](https://github.com/flex-development/pathe/commit/b2e088f690257ec723c20f3f40bffa686a49d110))
+* **lib:** [`format`] empty string handling ([5f0de54](https://github.com/flex-development/pathe/commit/5f0de54176e481c59d16320531bf2080e39d2aad))
+* **lib:** [`resolve`] drive-specific current working directory fallback ([4263bf9](https://github.com/flex-development/pathe/commit/4263bf9f224025df39cb614ae9c124eee876d339))
+
+
+### :house_with_garden: Housekeeping
+
+* cleanup build config ([c0ada79](https://github.com/flex-development/pathe/commit/c0ada79d8fa8dfbeb960275272d0bf36cf6a5eb3))
+* **github:** add commit scope `interfaces` ([c1d491b](https://github.com/flex-development/pathe/commit/c1d491bee529cae367f1b7934a793b29fa1678fd))
+* **github:** add commit scope `types` ([785ba57](https://github.com/flex-development/pathe/commit/785ba575ef3ece2e8cdf11ddb6c531a5aeed1ab2))
+* **pkg:** add keyword `forwardslash` ([28bad87](https://github.com/flex-development/pathe/commit/28bad87003bf2c9427d88f32bec7e67e437a9ef5))
+* **tests:** local codecov integration ([6bc2306](https://github.com/flex-development/pathe/commit/6bc23062f3c86973d37522e95da696de7b3fbc9d))
+* **tests:** qa ([effc686](https://github.com/flex-development/pathe/commit/effc686bb57da47ff3aa90ad38cd272b1a95129a))
+* **utils:** fix test names ([78404f5](https://github.com/flex-development/pathe/commit/78404f5f3681657af6409eaa4f4e701ea59913db))
+
+
+### :zap: Refactors
+
+* **lib:** qa ([f61889c](https://github.com/flex-development/pathe/commit/f61889c35840239cbf839099e52f2f3126469c81))
+* **utils:** [`changeExt`] allow file extension removal ([3d069cb](https://github.com/flex-development/pathe/commit/3d069cb584b7d21434c9aaa55eb4c60ca26e37b8))
+* **utils:** expose `formatExt` as utility ([e58f9e2](https://github.com/flex-development/pathe/commit/e58f9e287ae9bc20b41e680e24f2c04239b4bcd8))
+* **utils:** qa ([fda2454](https://github.com/flex-development/pathe/commit/fda2454660f85ad27b97c422bab42a751bf46c5c))
+
+
+### :white_check_mark: Testing
+
+* **lib:** add type tests ([8f3d59e](https://github.com/flex-development/pathe/commit/8f3d59e16201db971eaf02580bdaaa2c58d84f4b))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/pathe",
   "description": "Universal drop-in replacement for node:path",
-  "version": "0.0.0",
+  "version": "1.0.0",
   "keywords": [
     "backslash",
     "filesystem",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.0`
- added `CHANGELOG` entry for `1.0.0`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.25.5
      Coverage enabled with c8

 ✓ src/internal/__tests__/is-sep.spec-d.ts > unit-d:internal/isSep > should guard Sep
 ✓ src/interfaces/__tests__/platform-path.spec-d.ts > unit-d:interfaces/PlatformPath > should match path.PlatformPath
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > should return false if path not UNC path
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > should return true if path is UNC path
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > exact > should return true if path starts with exactly two separators
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should extend Required<PathObject>
 ✓ src/interfaces/__tests__/pathe.spec-d.ts > unit-d:interfaces/Pathe > should match PlatformPath
 ✓ src/internal/__tests__/is-drive-path.spec.ts > unit:internal/isDrivePath > should return false if path does not start with disk designator
 ✓ src/internal/__tests__/is-drive-path.spec.ts > unit:internal/isDrivePath > should return true if path starts with disk designator
 ✓ src/internal/__tests__/is-sep.spec.ts > unit:internal/isSep > should return false if value is not path separator
 ✓ src/internal/__tests__/is-sep.spec.ts > unit:internal/isSep > should return true if value is path separator
 ✓ src/__tests__/pathe.spec-d.ts > unit-d:pathe > should match typeof import("node:path")
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should allow empty object
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [base?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [dir?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [ext?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [name?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [root?: string]
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error code
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error message
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error name
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect bigint
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect boolean
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect function
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect instance object
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect null
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect number
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect string
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect symbol
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect undefined
 ✓ src/internal/__tests__/ensure-posix.spec.ts > unit:internal/ensurePosix > should return path that meets posix standards
 ✓ src/lib/__tests__/basename.spec-d.ts > unit-d:lib/basename > should match PlatformPath#basename
 ✓ src/lib/__tests__/delimiter.spec-d.ts > unit-d:lib/delimiter > should match PlatformPath#delimiter
 ✓ src/internal/__tests__/node-error.spec.ts > unit:internal/NodeError > constructor > should override error name
 ✓ src/internal/__tests__/node-error.spec.ts > unit:internal/NodeError > constructor > should set error code
 ✓ src/internal/__tests__/validate-object.spec.ts > unit:internal/validateObject > should return true if value is an object
 ✓ src/internal/__tests__/validate-object.spec.ts > unit:internal/validateObject > should throw if value is not an object
 ✓ src/lib/__tests__/delimiter.spec.ts > unit:lib/delimiter > should return posix path delimiter
 ✓ src/lib/__tests__/dirname.spec-d.ts > unit-d:lib/dirname > should match PlatformPath#dirname
 ✓ src/internal/__tests__/normalize-string.spec.ts > unit:internal/normalizeString > should return normalized string
 ✓ src/internal/__tests__/normalize-string.spec.ts > unit:internal/normalizeString > windows > should return normalized string
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should ignore suffix if not found in path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should return last portion of path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should return last portion of path without suffix
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should ignore suffix if not found in path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should return last portion of path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should return last portion of path without suffix
 ✓ src/internal/__tests__/validate-string.spec.ts > unit:internal/validateString > should return value if value is typeof string
 ✓ src/internal/__tests__/validate-string.spec.ts > unit:internal/validateString > should throw if value is not typeof string
 ✓ src/lib/__tests__/extname.spec-d.ts > unit-d:lib/extname > should match PlatformPath#extname
 ✓ src/lib/__tests__/dirname.spec.ts > unit:lib/dirname > should return directory name of path
 ✓ src/lib/__tests__/dirname.spec.ts > unit:lib/dirname > windows > should return directory name of path
 ✓ src/lib/__tests__/format.spec.ts > unit:lib/format > should return path string from object
 ✓ src/lib/__tests__/format.spec.ts > unit:lib/format > windows > should return path string from object
 ✓ src/lib/__tests__/format.spec-d.ts > unit-d:lib/format > should match PlatformPath#format
 ✓ src/lib/__tests__/extname.spec.ts > unit:lib/extname > should return extension name of path
 ✓ src/lib/__tests__/extname.spec.ts > unit:lib/extname > windows > should return extension name of path
 ✓ src/lib/__tests__/join.spec-d.ts > unit-d:lib/join > should match PlatformPath#join
 ✓ src/lib/__tests__/is-absolute.spec-d.ts > unit-d:lib/isAbsolute > should match PlatformPath#isAbsolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > should return false if path is not absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > should return true if path is absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > windows > should return false if path is not absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > windows > should return true if path is absolute
 ✓ src/lib/__tests__/join.spec.ts > unit:lib/join > should return joined path
 ✓ src/lib/__tests__/join.spec.ts > unit:lib/join > windows > should return joined path
 ✓ src/lib/__tests__/normalize.spec-d.ts > unit-d:lib/normalize > should match PlatformPath#normalize
 ✓ src/lib/__tests__/parse.spec-d.ts > unit-d:lib/parse > should match PlatformPath#parse
 ✓ src/lib/__tests__/normalize.spec.ts > unit:lib/normalize > should return normalized path
 ✓ src/lib/__tests__/normalize.spec.ts > unit:lib/normalize > windows > should return normalized path
 ✓ src/lib/__tests__/parse.spec.ts > unit:lib/parse > should return parsed path object
 ✓ src/lib/__tests__/parse.spec.ts > unit:lib/parse > windows > should return parsed path object
 ✓ src/lib/__tests__/relative.spec-d.ts > unit-d:lib/relative > should match PlatformPath#relative
 ✓ src/lib/__tests__/sep.spec.ts > unit:lib/sep > should return posix segment separator
 ✓ src/lib/__tests__/resolve.spec-d.ts > unit-d:lib/resolve > should match PlatformPath#resolve
 ✓ src/lib/__tests__/sep.spec-d.ts > unit-d:lib/sep > should match PlatformPath#sep
 ✓ src/lib/__tests__/relative.spec.ts > unit:lib/relative > should return relative path
 ✓ src/lib/__tests__/relative.spec.ts > unit:lib/relative > windows > should return relative path
 ✓ src/lib/__tests__/to-namespaced-path.spec-d.ts > unit-d:lib/toNamespacedPath > should match PlatformPath#toNamespacedPath
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > should return "." on process.cwd() failure
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > should return absolute path
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > windows > should return "." on process.cwd() failure
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > windows > should return absolute path
 ✓ src/lib/__tests__/to-namespaced-path.spec.ts > unit:lib/toNamespacedPath > should return path if path is not drive path or unc path
 ✓ src/lib/__tests__/to-namespaced-path.spec.ts > unit:lib/toNamespacedPath > windows > should return namespace-prefixed path
 ✓ src/types/__tests__/delimiter.spec-d.ts > unit-d:types/Delimiter > should extract posix path delimiter
 ✓ src/types/__tests__/ext.spec-d.ts > unit-d:types/Ext > should allow dot character
 ✓ src/types/__tests__/ext.spec-d.ts > unit-d:types/Ext > should allow string beginning with dot character
 ✓ src/types/__tests__/sep.spec-d.ts > unit-d:types/Sep > should extract posix path segment separator
 ✓ src/utils/__tests__/add-ext.spec-d.ts > unit-d:utils/addExt > should match Pathe#addExt
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path with ext appended
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path without modications if ext is empty
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path without modications if path ends with ext
 ✓ src/utils/__tests__/change-ext.spec-d.ts > unit-d:utils/changeExt > should match Pathe#changeExt
 ✓ src/utils/__tests__/change-ext.spec.ts > unit:utils/changeExt > should return path with changed file extension
 ✓ src/utils/__tests__/change-ext.spec.ts > unit:utils/changeExt > should return path without modications if ext is nil
 ✓ src/utils/__tests__/default-ext.spec-d.ts > unit-d:utils/defaultExt > should match Pathe#defaultExt
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path with ext appended
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path without modications if ext is empty
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path without modications if path has extension
 ✓ src/utils/__tests__/remove-ext.spec.ts > unit:utils/removeExt > should return path with ext removed
 ✓ src/utils/__tests__/remove-ext.spec.ts > unit:utils/removeExt > should return path without modications if ext is empty
 ✓ src/utils/__tests__/remove-ext.spec-d.ts > unit-d:utils/removeExt > should match Pathe#removeExt
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return empty string if ext is empty
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return ext if ext starts with dot character
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return formatted file extension
 ✓ src/utils/__tests__/format-ext.spec-d.ts > unit-d:utils/formatExt > should match Pathe#formatExt

 Test Files  54 passed (54)
      Tests  106 passed (106)
   Start at  02:20:17
   Duration  13.48s (transform 607ms, setup 42.22s, collect 3.62s, tests 980ms)

 % Coverage report from c8
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |     100 |     100 |                   
 internal                 |     100 |      100 |     100 |     100 |                   
  constants.ts            |     100 |      100 |     100 |     100 |                   
  ensure-posix.ts         |     100 |      100 |     100 |     100 |                   
  err-invalid-arg-type.ts |     100 |      100 |     100 |     100 |                   
  is-drive-path.ts        |     100 |      100 |     100 |     100 |                   
  is-sep.ts               |     100 |      100 |     100 |     100 |                   
  is-unc-path.ts          |     100 |      100 |     100 |     100 |                   
  node-error.ts           |     100 |      100 |     100 |     100 |                   
  normalize-string.ts     |     100 |      100 |     100 |     100 |                   
  validate-object.ts      |     100 |      100 |     100 |     100 |                   
  validate-string.ts      |     100 |      100 |     100 |     100 |                   
 lib                      |     100 |      100 |     100 |     100 |                   
  basename.ts             |     100 |      100 |     100 |     100 |                   
  delimiter.ts            |     100 |      100 |     100 |     100 |                   
  dirname.ts              |     100 |      100 |     100 |     100 |                   
  extname.ts              |     100 |      100 |     100 |     100 |                   
  format.ts               |     100 |      100 |     100 |     100 |                   
  is-absolute.ts          |     100 |      100 |     100 |     100 |                   
  join.ts                 |     100 |      100 |     100 |     100 |                   
  normalize.ts            |     100 |      100 |     100 |     100 |                   
  parse.ts                |     100 |      100 |     100 |     100 |                   
  relative.ts             |     100 |      100 |     100 |     100 |                   
  resolve.ts              |     100 |      100 |     100 |     100 |                   
  sep.ts                  |     100 |      100 |     100 |     100 |                   
  to-namespaced-path.ts   |     100 |      100 |     100 |     100 |                   
 utils                    |     100 |      100 |     100 |     100 |                   
  add-ext.ts              |     100 |      100 |     100 |     100 |                   
  change-ext.ts           |     100 |      100 |     100 |     100 |                   
  default-ext.ts          |     100 |      100 |     100 |     100 |                   
  format-ext.ts           |     100 |      100 |     100 |     100 |                   
  remove-ext.ts           |     100 |      100 |     100 |     100 |                   
--------------------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: @flex-development/pathe@workspace:. STDOUT ℹ Building @flex-development/pathe
➤ YN0000: @flex-development/pathe@workspace:. STDOUT ✔ Build succeeded for @flex-development/pathe
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   dist (total size: 86 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.mjs.map (167 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.mjs (251 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.d.mts (206 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.mjs.map (974 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.mjs (1.17 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.d.mts (436 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.d.mts (337 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.mjs (41 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.d.mts (530 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.mjs (41 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.d.mts (1.24 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.d.mts (3.15 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.mjs (43 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.d.mts (8.59 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.mjs.map (152 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.mjs (345 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.d.mts (726 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.mjs.map (281 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.mjs (384 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.d.mts (681 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.mjs.map (777 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.mjs (1.27 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.d.mts (1.01 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.mjs.map (241 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.mjs (332 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.d.mts (688 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.mjs.map (163 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.mjs (176 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.d.mts (363 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.mjs.map (290 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.mjs (396 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.d.mts (551 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.mjs.map (293 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.mjs (330 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.d.mts (777 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.mjs.map (1.51 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.mjs (2.08 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.d.mts (709 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.mjs.map (302 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.mjs (400 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.d.mts (609 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.mjs.map (251 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.mjs (352 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.d.mts (548 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.mjs.map (1.28 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.mjs (1.68 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.d.mts (568 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.mjs.map (130 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.mjs (140 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.d.mts (227 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.mjs.map (1.37 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.mjs (1.77 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.d.mts (466 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.mjs.map (953 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.mjs (1.28 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.d.mts (781 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.mjs.map (603 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.mjs (949 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.d.mts (1.13 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.mjs.map (426 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.mjs (1.01 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.d.mts (703 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.mjs.map (372 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.mjs (550 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.d.mts (434 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.mjs.map (930 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.mjs (1.33 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.d.mts (645 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.mjs.map (1.5 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.mjs (1.99 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.d.mts (704 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.mjs.map (731 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.mjs (1.09 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.d.mts (747 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.mjs.map (1.67 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.mjs (2.13 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.d.mts (757 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.mjs.map (1.97 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.mjs (2.81 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.d.mts (1.25 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.mjs.map (122 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.mjs (110 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.d.mts (232 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.mjs.map (617 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.mjs (883 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.d.mts (749 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.mjs (39 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.d.mts (166 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.mjs (33 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.d.mts (158 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.d.mts (218 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.mjs (33 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.d.mts (203 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.mjs.map (397 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.mjs (500 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.d.mts (857 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.mjs.map (517 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.mjs (721 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.d.mts (959 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.mjs.map (660 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.mjs (895 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.d.mts (1.12 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.mjs.map (195 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.mjs (204 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.d.mts (772 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.mjs.map (228 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.mjs (427 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.d.mts (325 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.mjs.map (370 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.mjs (481 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.d.mts (873 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT Σ Total build size: 86 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/interfaces/index.d.mts
➤ YN0000: dist/interfaces/index.mjs
➤ YN0000: dist/interfaces/index.mjs.map
➤ YN0000: dist/interfaces/parsed-path.d.mts
➤ YN0000: dist/interfaces/parsed-path.mjs
➤ YN0000: dist/interfaces/parsed-path.mjs.map
➤ YN0000: dist/interfaces/path-object.d.mts
➤ YN0000: dist/interfaces/path-object.mjs
➤ YN0000: dist/interfaces/path-object.mjs.map
➤ YN0000: dist/interfaces/pathe.d.mts
➤ YN0000: dist/interfaces/pathe.mjs
➤ YN0000: dist/interfaces/pathe.mjs.map
➤ YN0000: dist/interfaces/platform-path.d.mts
➤ YN0000: dist/interfaces/platform-path.mjs
➤ YN0000: dist/interfaces/platform-path.mjs.map
➤ YN0000: dist/internal/constants.d.mts
➤ YN0000: dist/internal/constants.mjs
➤ YN0000: dist/internal/constants.mjs.map
➤ YN0000: dist/internal/ensure-posix.d.mts
➤ YN0000: dist/internal/ensure-posix.mjs
➤ YN0000: dist/internal/ensure-posix.mjs.map
➤ YN0000: dist/internal/err-invalid-arg-type.d.mts
➤ YN0000: dist/internal/err-invalid-arg-type.mjs
➤ YN0000: dist/internal/err-invalid-arg-type.mjs.map
➤ YN0000: dist/internal/is-drive-path.d.mts
➤ YN0000: dist/internal/is-drive-path.mjs
➤ YN0000: dist/internal/is-drive-path.mjs.map
➤ YN0000: dist/internal/is-sep.d.mts
➤ YN0000: dist/internal/is-sep.mjs
➤ YN0000: dist/internal/is-sep.mjs.map
➤ YN0000: dist/internal/is-unc-path.d.mts
➤ YN0000: dist/internal/is-unc-path.mjs
➤ YN0000: dist/internal/is-unc-path.mjs.map
➤ YN0000: dist/internal/node-error.d.mts
➤ YN0000: dist/internal/node-error.mjs
➤ YN0000: dist/internal/node-error.mjs.map
➤ YN0000: dist/internal/normalize-string.d.mts
➤ YN0000: dist/internal/normalize-string.mjs
➤ YN0000: dist/internal/normalize-string.mjs.map
➤ YN0000: dist/internal/validate-object.d.mts
➤ YN0000: dist/internal/validate-object.mjs
➤ YN0000: dist/internal/validate-object.mjs.map
➤ YN0000: dist/internal/validate-string.d.mts
➤ YN0000: dist/internal/validate-string.mjs
➤ YN0000: dist/internal/validate-string.mjs.map
➤ YN0000: dist/lib/basename.d.mts
➤ YN0000: dist/lib/basename.mjs
➤ YN0000: dist/lib/basename.mjs.map
➤ YN0000: dist/lib/delimiter.d.mts
➤ YN0000: dist/lib/delimiter.mjs
➤ YN0000: dist/lib/delimiter.mjs.map
➤ YN0000: dist/lib/dirname.d.mts
➤ YN0000: dist/lib/dirname.mjs
➤ YN0000: dist/lib/dirname.mjs.map
➤ YN0000: dist/lib/extname.d.mts
➤ YN0000: dist/lib/extname.mjs
➤ YN0000: dist/lib/extname.mjs.map
➤ YN0000: dist/lib/format.d.mts
➤ YN0000: dist/lib/format.mjs
➤ YN0000: dist/lib/format.mjs.map
➤ YN0000: dist/lib/index.d.mts
➤ YN0000: dist/lib/index.mjs
➤ YN0000: dist/lib/index.mjs.map
➤ YN0000: dist/lib/is-absolute.d.mts
➤ YN0000: dist/lib/is-absolute.mjs
➤ YN0000: dist/lib/is-absolute.mjs.map
➤ YN0000: dist/lib/join.d.mts
➤ YN0000: dist/lib/join.mjs
➤ YN0000: dist/lib/join.mjs.map
➤ YN0000: dist/lib/normalize.d.mts
➤ YN0000: dist/lib/normalize.mjs
➤ YN0000: dist/lib/normalize.mjs.map
➤ YN0000: dist/lib/parse.d.mts
➤ YN0000: dist/lib/parse.mjs
➤ YN0000: dist/lib/parse.mjs.map
➤ YN0000: dist/lib/relative.d.mts
➤ YN0000: dist/lib/relative.mjs
➤ YN0000: dist/lib/relative.mjs.map
➤ YN0000: dist/lib/resolve.d.mts
➤ YN0000: dist/lib/resolve.mjs
➤ YN0000: dist/lib/resolve.mjs.map
➤ YN0000: dist/lib/sep.d.mts
➤ YN0000: dist/lib/sep.mjs
➤ YN0000: dist/lib/sep.mjs.map
➤ YN0000: dist/lib/to-namespaced-path.d.mts
➤ YN0000: dist/lib/to-namespaced-path.mjs
➤ YN0000: dist/lib/to-namespaced-path.mjs.map
➤ YN0000: dist/pathe.d.mts
➤ YN0000: dist/pathe.mjs
➤ YN0000: dist/pathe.mjs.map
➤ YN0000: dist/types/delimiter.d.mts
➤ YN0000: dist/types/delimiter.mjs
➤ YN0000: dist/types/delimiter.mjs.map
➤ YN0000: dist/types/ext.d.mts
➤ YN0000: dist/types/ext.mjs
➤ YN0000: dist/types/ext.mjs.map
➤ YN0000: dist/types/index.d.mts
➤ YN0000: dist/types/index.mjs
➤ YN0000: dist/types/index.mjs.map
➤ YN0000: dist/types/sep.d.mts
➤ YN0000: dist/types/sep.mjs
➤ YN0000: dist/types/sep.mjs.map
➤ YN0000: dist/utils/add-ext.d.mts
➤ YN0000: dist/utils/add-ext.mjs
➤ YN0000: dist/utils/add-ext.mjs.map
➤ YN0000: dist/utils/change-ext.d.mts
➤ YN0000: dist/utils/change-ext.mjs
➤ YN0000: dist/utils/change-ext.mjs.map
➤ YN0000: dist/utils/default-ext.d.mts
➤ YN0000: dist/utils/default-ext.mjs
➤ YN0000: dist/utils/default-ext.mjs.map
➤ YN0000: dist/utils/format-ext.d.mts
➤ YN0000: dist/utils/format-ext.mjs
➤ YN0000: dist/utils/format-ext.mjs.map
➤ YN0000: dist/utils/index.d.mts
➤ YN0000: dist/utils/index.mjs
➤ YN0000: dist/utils/index.mjs.map
➤ YN0000: dist/utils/remove-ext.d.mts
➤ YN0000: dist/utils/remove-ext.mjs
➤ YN0000: dist/utils/remove-ext.mjs.map
➤ YN0000: package.json
➤ YN0000: src/index.ts
➤ YN0000: src/interfaces/index.ts
➤ YN0000: src/interfaces/parsed-path.ts
➤ YN0000: src/interfaces/path-object.ts
➤ YN0000: src/interfaces/pathe.ts
➤ YN0000: src/interfaces/platform-path.ts
➤ YN0000: src/internal/constants.ts
➤ YN0000: src/internal/ensure-posix.ts
➤ YN0000: src/internal/err-invalid-arg-type.ts
➤ YN0000: src/internal/is-drive-path.ts
➤ YN0000: src/internal/is-sep.ts
➤ YN0000: src/internal/is-unc-path.ts
➤ YN0000: src/internal/node-error.ts
➤ YN0000: src/internal/normalize-string.ts
➤ YN0000: src/internal/validate-object.ts
➤ YN0000: src/internal/validate-string.ts
➤ YN0000: src/lib/basename.ts
➤ YN0000: src/lib/delimiter.ts
➤ YN0000: src/lib/dirname.ts
➤ YN0000: src/lib/extname.ts
➤ YN0000: src/lib/format.ts
➤ YN0000: src/lib/index.ts
➤ YN0000: src/lib/is-absolute.ts
➤ YN0000: src/lib/join.ts
➤ YN0000: src/lib/normalize.ts
➤ YN0000: src/lib/parse.ts
➤ YN0000: src/lib/relative.ts
➤ YN0000: src/lib/resolve.ts
➤ YN0000: src/lib/sep.ts
➤ YN0000: src/lib/to-namespaced-path.ts
➤ YN0000: src/pathe.ts
➤ YN0000: src/types/delimiter.ts
➤ YN0000: src/types/ext.ts
➤ YN0000: src/types/index.ts
➤ YN0000: src/types/sep.ts
➤ YN0000: src/utils/add-ext.ts
➤ YN0000: src/utils/change-ext.ts
➤ YN0000: src/utils/default-ext.ts
➤ YN0000: src/utils/format-ext.ts
➤ YN0000: src/utils/index.ts
➤ YN0000: src/utils/remove-ext.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-pathe-1.0.0.tgz
➤ YN0000: Done in 5s 262ms
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

N/A

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/pathe/blob/main/CONTRIBUTING.md#pull-request-titles
