### PR TITLE
release: 1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## [1.0.1](https://github.com/flex-development/pathe/compare/1.0.0...1.0.1) (2022-12-20)
+
+
+### :robot: Continuous Integration
+
+* **workflows:** [`ci`] fix `yarn` step ([031cab5](https://github.com/flex-development/pathe/commit/031cab59c7e6c70325e0b004b5c05460490d57d0))
+
+
+### :bug: Fixes
+
+* **interfaces:** make `ParsedPath` work as expected with `--exactOptionalPropertyTypes` ([066665a](https://github.com/flex-development/pathe/commit/066665a0072c91302d9fda396c607a5863ac4028))
+
 ## 1.0.0 (2022-12-16)
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@flex-development/pathe",
   "description": "Universal drop-in replacement for node:path",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "keywords": [
     "backslash",
     "filesystem",


### PR DESCRIPTION
## Description

<!-- A clear and concise description of your changes. -->

- bumped version to `1.0.1`
- added `CHANGELOG` entry for `1.0.1`

## Tests

<!-- What did you test? List tests, include snippet from test suites, or write "N/A" if tests were not needed. -->

### `yarn test:cov`

```zsh
 RUN  v0.25.5
      Coverage enabled with c8

 ✓ src/__tests__/pathe.spec-d.ts > unit-d:pathe > should match typeof import("node:path")
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should allow empty object
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [base?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [dir?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [ext?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [name?: string]
 ✓ src/interfaces/__tests__/path-object.spec-d.ts > unit-d:interfaces/PathObject > should match [root?: string]
 ✓ src/interfaces/__tests__/pathe.spec-d.ts > unit-d:interfaces/Pathe > should match PlatformPath
 ✓ src/internal/__tests__/is-sep.spec.ts > unit:internal/isSep > should return false if value is not path separator
 ✓ src/internal/__tests__/is-sep.spec.ts > unit:internal/isSep > should return true if value is path separator
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should match [base: string]
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should match [dir: string]
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should match [ext: string]
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should match [name: string]
 ✓ src/interfaces/__tests__/parsed-path.spec-d.ts > unit-d:interfaces/ParsedPath > should match [root: string]
 ✓ src/internal/__tests__/is-sep.spec-d.ts > unit-d:internal/isSep > should guard Sep
 ✓ src/internal/__tests__/ensure-posix.spec.ts > unit:internal/ensurePosix > should return path that meets posix standards
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error code
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error message
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > constructor > should set error name
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect bigint
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect boolean
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect function
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect instance object
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect null
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect number
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect string
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect symbol
 ✓ src/internal/__tests__/err-invalid-arg-type.spec.ts > unit:internal/ERR_INVALID_ARG_TYPE > #determineSpecificType > should detect undefined
 ✓ src/interfaces/__tests__/platform-path.spec-d.ts > unit-d:interfaces/PlatformPath > should match path.PlatformPath
 ✓ src/internal/__tests__/is-drive-path.spec.ts > unit:internal/isDrivePath > should return false if path does not start with disk designator
 ✓ src/internal/__tests__/is-drive-path.spec.ts > unit:internal/isDrivePath > should return true if path starts with disk designator
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > should return false if path not UNC path
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > should return true if path is UNC path
 ✓ src/internal/__tests__/is-unc-path.spec.ts > unit:internal/isUncPath > exact > should return true if path starts with exactly two separators
 ✓ src/internal/__tests__/node-error.spec.ts > unit:internal/NodeError > constructor > should override error name
 ✓ src/internal/__tests__/node-error.spec.ts > unit:internal/NodeError > constructor > should set error code
 ✓ src/lib/__tests__/basename.spec-d.ts > unit-d:lib/basename > should match PlatformPath#basename
 ✓ src/internal/__tests__/validate-object.spec.ts > unit:internal/validateObject > should return true if value is an object
 ✓ src/internal/__tests__/validate-object.spec.ts > unit:internal/validateObject > should throw if value is not an object
 ✓ src/lib/__tests__/delimiter.spec-d.ts > unit-d:lib/delimiter > should match PlatformPath#delimiter
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should ignore suffix if not found in path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should return last portion of path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > should return last portion of path without suffix
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should ignore suffix if not found in path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should return last portion of path
 ✓ src/lib/__tests__/basename.spec.ts > unit:lib/basename > windows > should return last portion of path without suffix
 ✓ src/internal/__tests__/normalize-string.spec.ts > unit:internal/normalizeString > should return normalized string
 ✓ src/internal/__tests__/normalize-string.spec.ts > unit:internal/normalizeString > windows > should return normalized string
 ✓ src/lib/__tests__/dirname.spec.ts > unit:lib/dirname > should return directory name of path
 ✓ src/lib/__tests__/dirname.spec.ts > unit:lib/dirname > windows > should return directory name of path
 ✓ src/internal/__tests__/validate-string.spec.ts > unit:internal/validateString > should return value if value is typeof string
 ✓ src/internal/__tests__/validate-string.spec.ts > unit:internal/validateString > should throw if value is not typeof string
 ✓ src/lib/__tests__/extname.spec-d.ts > unit-d:lib/extname > should match PlatformPath#extname
 ✓ src/lib/__tests__/dirname.spec-d.ts > unit-d:lib/dirname > should match PlatformPath#dirname
 ✓ src/lib/__tests__/delimiter.spec.ts > unit:lib/delimiter > should return posix path delimiter
 ✓ src/lib/__tests__/extname.spec.ts > unit:lib/extname > should return extension name of path
 ✓ src/lib/__tests__/extname.spec.ts > unit:lib/extname > windows > should return extension name of path
 ✓ src/lib/__tests__/format.spec-d.ts > unit-d:lib/format > should match PlatformPath#format
 ✓ src/lib/__tests__/join.spec-d.ts > unit-d:lib/join > should match PlatformPath#join
 ✓ src/lib/__tests__/format.spec.ts > unit:lib/format > should return path string from object
 ✓ src/lib/__tests__/format.spec.ts > unit:lib/format > windows > should return path string from object
 ✓ src/lib/__tests__/is-absolute.spec-d.ts > unit-d:lib/isAbsolute > should match PlatformPath#isAbsolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > should return false if path is not absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > should return true if path is absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > windows > should return false if path is not absolute
 ✓ src/lib/__tests__/is-absolute.spec.ts > unit:lib/isAbsolute > windows > should return true if path is absolute
 ✓ src/lib/__tests__/normalize.spec.ts > unit:lib/normalize > should return normalized path
 ✓ src/lib/__tests__/normalize.spec.ts > unit:lib/normalize > windows > should return normalized path
 ✓ src/lib/__tests__/parse.spec-d.ts > unit-d:lib/parse > should match PlatformPath#parse
 ✓ src/lib/__tests__/join.spec.ts > unit:lib/join > should return joined path
 ✓ src/lib/__tests__/join.spec.ts > unit:lib/join > windows > should return joined path
 ✓ src/lib/__tests__/normalize.spec-d.ts > unit-d:lib/normalize > should match PlatformPath#normalize
 ✓ src/lib/__tests__/parse.spec.ts > unit:lib/parse > should return parsed path object
 ✓ src/lib/__tests__/parse.spec.ts > unit:lib/parse > windows > should return parsed path object
 ✓ src/lib/__tests__/relative.spec-d.ts > unit-d:lib/relative > should match PlatformPath#relative
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > should return "." on process.cwd() failure
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > should return absolute path
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > windows > should return "." on process.cwd() failure
 ✓ src/lib/__tests__/resolve.spec.ts > unit:lib/resolve > windows > should return absolute path
 ✓ src/lib/__tests__/resolve.spec-d.ts > unit-d:lib/resolve > should match PlatformPath#resolve
 ✓ src/lib/__tests__/relative.spec.ts > unit:lib/relative > should return relative path
 ✓ src/lib/__tests__/relative.spec.ts > unit:lib/relative > windows > should return relative path
 ✓ src/lib/__tests__/sep.spec.ts > unit:lib/sep > should return posix segment separator
 ✓ src/lib/__tests__/sep.spec-d.ts > unit-d:lib/sep > should match PlatformPath#sep
 ✓ src/lib/__tests__/to-namespaced-path.spec-d.ts > unit-d:lib/toNamespacedPath > should match PlatformPath#toNamespacedPath
 ✓ src/types/__tests__/sep.spec-d.ts > unit-d:types/Sep > should extract posix path segment separator
 ✓ src/types/__tests__/delimiter.spec-d.ts > unit-d:types/Delimiter > should extract posix path delimiter
 ✓ src/types/__tests__/ext.spec-d.ts > unit-d:types/Ext > should allow dot character
 ✓ src/types/__tests__/ext.spec-d.ts > unit-d:types/Ext > should allow string beginning with dot character
 ✓ src/lib/__tests__/to-namespaced-path.spec.ts > unit:lib/toNamespacedPath > should return path if path is not drive path or unc path
 ✓ src/lib/__tests__/to-namespaced-path.spec.ts > unit:lib/toNamespacedPath > windows > should return namespace-prefixed path
 ✓ src/utils/__tests__/add-ext.spec-d.ts > unit-d:utils/addExt > should match Pathe#addExt
 ✓ src/utils/__tests__/change-ext.spec-d.ts > unit-d:utils/changeExt > should match Pathe#changeExt
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path with ext appended
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path without modications if ext is empty
 ✓ src/utils/__tests__/add-ext.spec.ts > unit:utils/addExt > should return path without modications if path ends with ext
 ✓ src/utils/__tests__/default-ext.spec-d.ts > unit-d:utils/defaultExt > should match Pathe#defaultExt
 ✓ src/utils/__tests__/change-ext.spec.ts > unit:utils/changeExt > should return path with changed file extension
 ✓ src/utils/__tests__/change-ext.spec.ts > unit:utils/changeExt > should return path without modications if ext is nil
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return empty string if ext is empty
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return ext if ext starts with dot character
 ✓ src/utils/__tests__/format-ext.spec.ts > unit:utils/formatExt > should return formatted file extension
 ✓ src/utils/__tests__/format-ext.spec-d.ts > unit-d:utils/formatExt > should match Pathe#formatExt
 ✓ src/utils/__tests__/remove-ext.spec-d.ts > unit-d:utils/removeExt > should match Pathe#removeExt
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path with ext appended
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path without modications if ext is empty
 ✓ src/utils/__tests__/default-ext.spec.ts > unit:utils/defaultExt > should return path without modications if path has extension
 ✓ src/utils/__tests__/remove-ext.spec.ts > unit:utils/removeExt > should return path with ext removed
 ✓ src/utils/__tests__/remove-ext.spec.ts > unit:utils/removeExt > should return path without modications if ext is empty

 Test Files  54 passed (54)
      Tests  110 passed (110)
   Start at  18:04:43
   Duration  12.01s (transform 536ms, setup 35.47s, collect 2.89s, tests 504ms)

 % Coverage report from c8
--------------------------|---------|----------|---------|---------|-------------------
File                      | % Stmts | % Branch | % Funcs | % Lines | Uncovered Line #s 
--------------------------|---------|----------|---------|---------|-------------------
All files                 |     100 |      100 |     100 |     100 |                   
 internal                 |     100 |      100 |     100 |     100 |                   
  constants.ts            |     100 |      100 |     100 |     100 |                   
  ensure-posix.ts         |     100 |      100 |     100 |     100 |                   
  err-invalid-arg-type.ts |     100 |      100 |     100 |     100 |                   
  is-drive-path.ts        |     100 |      100 |     100 |     100 |                   
  is-sep.ts               |     100 |      100 |     100 |     100 |                   
  is-unc-path.ts          |     100 |      100 |     100 |     100 |                   
  node-error.ts           |     100 |      100 |     100 |     100 |                   
  normalize-string.ts     |     100 |      100 |     100 |     100 |                   
  validate-object.ts      |     100 |      100 |     100 |     100 |                   
  validate-string.ts      |     100 |      100 |     100 |     100 |                   
 lib                      |     100 |      100 |     100 |     100 |                   
  basename.ts             |     100 |      100 |     100 |     100 |                   
  delimiter.ts            |     100 |      100 |     100 |     100 |                   
  dirname.ts              |     100 |      100 |     100 |     100 |                   
  extname.ts              |     100 |      100 |     100 |     100 |                   
  format.ts               |     100 |      100 |     100 |     100 |                   
  is-absolute.ts          |     100 |      100 |     100 |     100 |                   
  join.ts                 |     100 |      100 |     100 |     100 |                   
  normalize.ts            |     100 |      100 |     100 |     100 |                   
  parse.ts                |     100 |      100 |     100 |     100 |                   
  relative.ts             |     100 |      100 |     100 |     100 |                   
  resolve.ts              |     100 |      100 |     100 |     100 |                   
  sep.ts                  |     100 |      100 |     100 |     100 |                   
  to-namespaced-path.ts   |     100 |      100 |     100 |     100 |                   
 utils                    |     100 |      100 |     100 |     100 |                   
  add-ext.ts              |     100 |      100 |     100 |     100 |                   
  change-ext.ts           |     100 |      100 |     100 |     100 |                   
  default-ext.ts          |     100 |      100 |     100 |     100 |                   
  format-ext.ts           |     100 |      100 |     100 |     100 |                   
  remove-ext.ts           |     100 |      100 |     100 |     100 |                   
--------------------------|---------|----------|---------|---------|-------------------
```

### `yarn pack -o %s-%v.tgz`

```zsh
➤ YN0036: Calling the "prepack" lifecycle script
➤ YN0000: @flex-development/pathe@workspace:. STDOUT ℹ Building @flex-development/pathe
➤ YN0000: @flex-development/pathe@workspace:. STDOUT ✔ Build succeeded for @flex-development/pathe
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   dist (total size: 86.2 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.mjs.map (167 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.mjs (251 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/index.d.mts (206 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.mjs.map (974 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.mjs (1.17 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/pathe.d.mts (436 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/index.d.mts (337 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.mjs (41 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/parsed-path.d.mts (662 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.mjs (41 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/path-object.d.mts (1.24 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/pathe.d.mts (3.15 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.mjs (43 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/interfaces/platform-path.d.mts (8.59 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.mjs.map (152 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.mjs (345 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/constants.d.mts (726 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.mjs.map (281 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.mjs (384 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/ensure-posix.d.mts (681 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.mjs.map (777 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.mjs (1.27 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/err-invalid-arg-type.d.mts (1.01 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.mjs.map (241 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.mjs (332 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-drive-path.d.mts (688 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.mjs.map (163 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.mjs (176 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-sep.d.mts (363 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.mjs.map (290 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.mjs (396 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/is-unc-path.d.mts (551 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.mjs.map (293 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.mjs (330 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/node-error.d.mts (777 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.mjs.map (1.51 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.mjs (2.08 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/normalize-string.d.mts (709 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.mjs.map (302 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.mjs (400 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-object.d.mts (609 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.mjs.map (251 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.mjs (352 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/internal/validate-string.d.mts (548 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.mjs.map (1.28 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.mjs (1.68 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/basename.d.mts (568 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.mjs.map (130 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.mjs (140 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/delimiter.d.mts (227 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.mjs.map (1.37 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.mjs (1.77 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/dirname.d.mts (466 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.mjs.map (953 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.mjs (1.28 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/extname.d.mts (781 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.mjs.map (603 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.mjs (949 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/format.d.mts (1.13 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.mjs.map (426 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.mjs (1.01 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/index.d.mts (703 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.mjs.map (372 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.mjs (550 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/is-absolute.d.mts (434 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.mjs.map (930 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.mjs (1.33 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/join.d.mts (645 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.mjs.map (1.5 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.mjs (1.99 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/normalize.d.mts (704 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.mjs.map (731 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.mjs (1.09 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/parse.d.mts (747 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.mjs.map (1.67 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.mjs (2.13 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/relative.d.mts (757 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.mjs.map (1.97 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.mjs (2.81 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/resolve.d.mts (1.25 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.mjs.map (122 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.mjs (110 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/sep.d.mts (232 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.mjs.map (617 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.mjs (883 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/lib/to-namespaced-path.d.mts (749 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.mjs (39 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/delimiter.d.mts (166 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.mjs (33 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/ext.d.mts (158 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.mjs (35 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/index.d.mts (218 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.mjs.map (69 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.mjs (33 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/types/sep.d.mts (203 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.mjs.map (397 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.mjs (500 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/add-ext.d.mts (857 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.mjs.map (517 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.mjs (721 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/change-ext.d.mts (959 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.mjs.map (660 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.mjs (895 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/default-ext.d.mts (1.12 kB)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.mjs.map (195 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.mjs (204 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/format-ext.d.mts (772 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.mjs.map (228 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.mjs (427 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/index.d.mts (325 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.mjs.map (370 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.mjs (481 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT   └─ dist/utils/remove-ext.d.mts (873 B)
➤ YN0000: @flex-development/pathe@workspace:. STDOUT Σ Total build size: 86.2 kB
➤ YN0000: CHANGELOG.md
➤ YN0000: LICENSE.md
➤ YN0000: README.md
➤ YN0000: changelog.config.cts
➤ YN0000: dist/index.d.mts
➤ YN0000: dist/index.mjs
➤ YN0000: dist/index.mjs.map
➤ YN0000: dist/interfaces/index.d.mts
➤ YN0000: dist/interfaces/index.mjs
➤ YN0000: dist/interfaces/index.mjs.map
➤ YN0000: dist/interfaces/parsed-path.d.mts
➤ YN0000: dist/interfaces/parsed-path.mjs
➤ YN0000: dist/interfaces/parsed-path.mjs.map
➤ YN0000: dist/interfaces/path-object.d.mts
➤ YN0000: dist/interfaces/path-object.mjs
➤ YN0000: dist/interfaces/path-object.mjs.map
➤ YN0000: dist/interfaces/pathe.d.mts
➤ YN0000: dist/interfaces/pathe.mjs
➤ YN0000: dist/interfaces/pathe.mjs.map
➤ YN0000: dist/interfaces/platform-path.d.mts
➤ YN0000: dist/interfaces/platform-path.mjs
➤ YN0000: dist/interfaces/platform-path.mjs.map
➤ YN0000: dist/internal/constants.d.mts
➤ YN0000: dist/internal/constants.mjs
➤ YN0000: dist/internal/constants.mjs.map
➤ YN0000: dist/internal/ensure-posix.d.mts
➤ YN0000: dist/internal/ensure-posix.mjs
➤ YN0000: dist/internal/ensure-posix.mjs.map
➤ YN0000: dist/internal/err-invalid-arg-type.d.mts
➤ YN0000: dist/internal/err-invalid-arg-type.mjs
➤ YN0000: dist/internal/err-invalid-arg-type.mjs.map
➤ YN0000: dist/internal/is-drive-path.d.mts
➤ YN0000: dist/internal/is-drive-path.mjs
➤ YN0000: dist/internal/is-drive-path.mjs.map
➤ YN0000: dist/internal/is-sep.d.mts
➤ YN0000: dist/internal/is-sep.mjs
➤ YN0000: dist/internal/is-sep.mjs.map
➤ YN0000: dist/internal/is-unc-path.d.mts
➤ YN0000: dist/internal/is-unc-path.mjs
➤ YN0000: dist/internal/is-unc-path.mjs.map
➤ YN0000: dist/internal/node-error.d.mts
➤ YN0000: dist/internal/node-error.mjs
➤ YN0000: dist/internal/node-error.mjs.map
➤ YN0000: dist/internal/normalize-string.d.mts
➤ YN0000: dist/internal/normalize-string.mjs
➤ YN0000: dist/internal/normalize-string.mjs.map
➤ YN0000: dist/internal/validate-object.d.mts
➤ YN0000: dist/internal/validate-object.mjs
➤ YN0000: dist/internal/validate-object.mjs.map
➤ YN0000: dist/internal/validate-string.d.mts
➤ YN0000: dist/internal/validate-string.mjs
➤ YN0000: dist/internal/validate-string.mjs.map
➤ YN0000: dist/lib/basename.d.mts
➤ YN0000: dist/lib/basename.mjs
➤ YN0000: dist/lib/basename.mjs.map
➤ YN0000: dist/lib/delimiter.d.mts
➤ YN0000: dist/lib/delimiter.mjs
➤ YN0000: dist/lib/delimiter.mjs.map
➤ YN0000: dist/lib/dirname.d.mts
➤ YN0000: dist/lib/dirname.mjs
➤ YN0000: dist/lib/dirname.mjs.map
➤ YN0000: dist/lib/extname.d.mts
➤ YN0000: dist/lib/extname.mjs
➤ YN0000: dist/lib/extname.mjs.map
➤ YN0000: dist/lib/format.d.mts
➤ YN0000: dist/lib/format.mjs
➤ YN0000: dist/lib/format.mjs.map
➤ YN0000: dist/lib/index.d.mts
➤ YN0000: dist/lib/index.mjs
➤ YN0000: dist/lib/index.mjs.map
➤ YN0000: dist/lib/is-absolute.d.mts
➤ YN0000: dist/lib/is-absolute.mjs
➤ YN0000: dist/lib/is-absolute.mjs.map
➤ YN0000: dist/lib/join.d.mts
➤ YN0000: dist/lib/join.mjs
➤ YN0000: dist/lib/join.mjs.map
➤ YN0000: dist/lib/normalize.d.mts
➤ YN0000: dist/lib/normalize.mjs
➤ YN0000: dist/lib/normalize.mjs.map
➤ YN0000: dist/lib/parse.d.mts
➤ YN0000: dist/lib/parse.mjs
➤ YN0000: dist/lib/parse.mjs.map
➤ YN0000: dist/lib/relative.d.mts
➤ YN0000: dist/lib/relative.mjs
➤ YN0000: dist/lib/relative.mjs.map
➤ YN0000: dist/lib/resolve.d.mts
➤ YN0000: dist/lib/resolve.mjs
➤ YN0000: dist/lib/resolve.mjs.map
➤ YN0000: dist/lib/sep.d.mts
➤ YN0000: dist/lib/sep.mjs
➤ YN0000: dist/lib/sep.mjs.map
➤ YN0000: dist/lib/to-namespaced-path.d.mts
➤ YN0000: dist/lib/to-namespaced-path.mjs
➤ YN0000: dist/lib/to-namespaced-path.mjs.map
➤ YN0000: dist/pathe.d.mts
➤ YN0000: dist/pathe.mjs
➤ YN0000: dist/pathe.mjs.map
➤ YN0000: dist/types/delimiter.d.mts
➤ YN0000: dist/types/delimiter.mjs
➤ YN0000: dist/types/delimiter.mjs.map
➤ YN0000: dist/types/ext.d.mts
➤ YN0000: dist/types/ext.mjs
➤ YN0000: dist/types/ext.mjs.map
➤ YN0000: dist/types/index.d.mts
➤ YN0000: dist/types/index.mjs
➤ YN0000: dist/types/index.mjs.map
➤ YN0000: dist/types/sep.d.mts
➤ YN0000: dist/types/sep.mjs
➤ YN0000: dist/types/sep.mjs.map
➤ YN0000: dist/utils/add-ext.d.mts
➤ YN0000: dist/utils/add-ext.mjs
➤ YN0000: dist/utils/add-ext.mjs.map
➤ YN0000: dist/utils/change-ext.d.mts
➤ YN0000: dist/utils/change-ext.mjs
➤ YN0000: dist/utils/change-ext.mjs.map
➤ YN0000: dist/utils/default-ext.d.mts
➤ YN0000: dist/utils/default-ext.mjs
➤ YN0000: dist/utils/default-ext.mjs.map
➤ YN0000: dist/utils/format-ext.d.mts
➤ YN0000: dist/utils/format-ext.mjs
➤ YN0000: dist/utils/format-ext.mjs.map
➤ YN0000: dist/utils/index.d.mts
➤ YN0000: dist/utils/index.mjs
➤ YN0000: dist/utils/index.mjs.map
➤ YN0000: dist/utils/remove-ext.d.mts
➤ YN0000: dist/utils/remove-ext.mjs
➤ YN0000: dist/utils/remove-ext.mjs.map
➤ YN0000: package.json
➤ YN0000: src/index.ts
➤ YN0000: src/interfaces/index.ts
➤ YN0000: src/interfaces/parsed-path.ts
➤ YN0000: src/interfaces/path-object.ts
➤ YN0000: src/interfaces/pathe.ts
➤ YN0000: src/interfaces/platform-path.ts
➤ YN0000: src/internal/constants.ts
➤ YN0000: src/internal/ensure-posix.ts
➤ YN0000: src/internal/err-invalid-arg-type.ts
➤ YN0000: src/internal/is-drive-path.ts
➤ YN0000: src/internal/is-sep.ts
➤ YN0000: src/internal/is-unc-path.ts
➤ YN0000: src/internal/node-error.ts
➤ YN0000: src/internal/normalize-string.ts
➤ YN0000: src/internal/validate-object.ts
➤ YN0000: src/internal/validate-string.ts
➤ YN0000: src/lib/basename.ts
➤ YN0000: src/lib/delimiter.ts
➤ YN0000: src/lib/dirname.ts
➤ YN0000: src/lib/extname.ts
➤ YN0000: src/lib/format.ts
➤ YN0000: src/lib/index.ts
➤ YN0000: src/lib/is-absolute.ts
➤ YN0000: src/lib/join.ts
➤ YN0000: src/lib/normalize.ts
➤ YN0000: src/lib/parse.ts
➤ YN0000: src/lib/relative.ts
➤ YN0000: src/lib/resolve.ts
➤ YN0000: src/lib/sep.ts
➤ YN0000: src/lib/to-namespaced-path.ts
➤ YN0000: src/pathe.ts
➤ YN0000: src/types/delimiter.ts
➤ YN0000: src/types/ext.ts
➤ YN0000: src/types/index.ts
➤ YN0000: src/types/sep.ts
➤ YN0000: src/utils/add-ext.ts
➤ YN0000: src/utils/change-ext.ts
➤ YN0000: src/utils/default-ext.ts
➤ YN0000: src/utils/format-ext.ts
➤ YN0000: src/utils/index.ts
➤ YN0000: src/utils/remove-ext.ts
➤ YN0036: Calling the "postpack" lifecycle script
➤ YN0000: Package archive generated in ./@flex-development-pathe-1.0.1.tgz
➤ YN0000: Done in 4s 930ms
```

## Linked issues

<!--
A list of linked issues and/or pull requests.

- <closes|fixes|resolves> #<issue-number>
- <prereleases|releases> #<pr-number>
-->

N/A

## Related documents

<!-- A list of related documents (e.g. docs, proposals, specs, etc), if any. -->

N/A

## Additional context

<!-- Include additional details here. Be sure to note if any tolerable vulnerabilities or warnings have been introduced. -->

N/A

## Submission checklist

- [x] self-review performed
- [x] tests added and/or updated
- [x] documentation added or updated
- [x] new, **tolerable** vulnerabilities and/or warnings documented, if any
- [x] [pr naming conventions][1]

[1]: https://github.com/flex-development/pathe/blob/main/CONTRIBUTING.md#pull-request-titles
